### PR TITLE
Simplifies data fetching logic in ConferenceEditors

### DIFF
--- a/src/components/Wyswig/index.tsx
+++ b/src/components/Wyswig/index.tsx
@@ -88,7 +88,7 @@ export const Wysiwyg: React.FC<WysiwygProps> = ({
         }
       } catch (err: any) {
         console.error("Image upload failed", err);
-        alert(err.response?.data?.message || "Image loading error");
+        alert(err.response?.data?.message || "Image loading zxc@scs.comerror");
       }
     };
   }, []);

--- a/src/containers/AdminPanelView/ConferenceEditorsView.tsx
+++ b/src/containers/AdminPanelView/ConferenceEditorsView.tsx
@@ -1,3 +1,4 @@
+
 import React, { useState, useEffect, useContext } from 'react';
 import { AuthContext } from '../../context/AuthContext';
 import { Editor } from '../../interfaces/Editros';
@@ -72,11 +73,7 @@ const ConferenceEditors: React.FC<ConferenceEditorsProps> = ({ conferenceId, onC
   };
 
   useEffect(() => {
-    fetchData(); 
-
-    const intervalId = setInterval(fetchData, 10000);
-
-    return () => clearInterval(intervalId);
+    fetchData(); // Fetch data only on mount or when conferenceId/token changes
   }, [conferenceId, token]);
 
   const handleAssignEditor = async (e: React.FormEvent) => {
@@ -105,7 +102,7 @@ const ConferenceEditors: React.FC<ConferenceEditorsProps> = ({ conferenceId, onC
       );
       setSuccess('Editor assigned successfully');
       setSelectedEditorId(null);
-      await fetchData();
+      await fetchData(); // Refresh data after assigning
     } catch (err: any) {
       setError(err.response?.data?.message || 'Failed to assign editor');
     } finally {
@@ -124,7 +121,7 @@ const ConferenceEditors: React.FC<ConferenceEditorsProps> = ({ conferenceId, onC
         withCredentials: true,
       });
       setSuccess('Editor removed successfully');
-      await fetchData();
+      await fetchData(); // Refresh data after deleting
     } catch (err: any) {
       setError(err.response?.data?.message || 'Failed to remove editor');
     }


### PR DESCRIPTION
Removes periodic data fetching with setInterval and simplifies data fetching logic to trigger only on mount or when dependencies change.

Enhances clarity by adding comments to refresh data after editor assignment or removal.